### PR TITLE
Separate parsing of normal and raw codes

### DIFF
--- a/lirc/lirc.py
+++ b/lirc/lirc.py
@@ -29,7 +29,8 @@ class Lirc:
 		Parse the lircd.conf config file and create a dictionary.
 		"""
 		remote_name = None
-		code_section = False
+		codes_section = False
+		raw_codes_section = False
 
 		for l in self.conf:
 			# Convert (multiple) tabs to spaces
@@ -43,7 +44,8 @@ class Lirc:
 			if l == 'begin remote':
 				# Got the start of a remote definition
 				remote_name = None
-				code_section = False
+				codes_section = False
+				raw_codes_section = False
 
 			elif not remote_name and l.startswith('name '):
 				# Got the name of the remote
@@ -55,15 +57,26 @@ class Lirc:
 				# Got to the end of a remote definition
 				remote_name = None
 
-			elif remote_name and (l == 'begin codes' or l == 'begin raw_codes'):
-				code_section = True
+			elif remote_name and l == 'begin codes':
+				codes_section = True
 
-			elif remote_name and (l == 'end codes' or l == 'end raw_codes'):
-				code_section = False
+			elif remote_name and l == 'end codes':
+				codes_section = False
 
-			elif remote_name and code_section and l.startswith('name '):
+			elif remote_name and l == 'begin raw_codes':
+				raw_codes_section = True
+
+			elif remote_name and l == 'end raw_codes':
+				raw_codes_section = False
+
+			elif remote_name and codes_section:
 				fields = l.split(' ')
-				self.codes[remote_name].add(fields[1])
+				self.codes[remote_name].add(fields[0])
+
+			elif remote_name and raw_codes_section:
+				fields = l.split(' ')
+				if len(fields) >= 2 and fields[0] == 'name':
+					self.codes[remote_name].add(fields[1])
 
 
 	def send_once(self, device_id, message):


### PR DESCRIPTION
This patch improves the parser of code sections. In particular, it no longer fails on malformed raw codes and it is able to parse a normal key named "name".